### PR TITLE
Handle Empty Domain

### DIFF
--- a/library/cloudflare_domain.py
+++ b/library/cloudflare_domain.py
@@ -115,7 +115,8 @@ class Cloudflare(object):
 
 def cloudflare_domain(module):
     cloudflare = Cloudflare(module.params['email'], module.params['token'], module.params['zone'])
-    existing_records = cloudflare.rec_load_all()['response']['recs']['objs']
+    responseRecordCollection = cloudflare.rec_load_all()['response']['recs']
+    existing_records = responseRecordCollection.get('objs', [])
 
     # Shortcuts
     get_record_attributes = itemgetter('name', 'type', 'content')


### PR DESCRIPTION
This PR provides a default value for the `existing_records` variable in the event a domain has no existing records.

I noticed recently while working with Cloudflare on a newly added domain that for some reason the API is returning 

```
{
  obj: None
}
```

rather than the more sensible 

```
{
  objs: []
}
```

When no records currently exist on a domain.

This change ensures an empty array is in place to prevent the module from choking on the bad `objs` reference.  I tried to get a test running but it seems like the tests are currently broken and I'm not experienced enough with Python to know how to properly fix them or if this is even the best fix for the problem. Either way it got me rolling again so I figured I'd open a PR.

Thanks for writing this module it really came in handy!